### PR TITLE
Add a link to promise-ring package to Convenience Utilities section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Native and strictly spec-compliant promises are awesome for compatibility, futur
 * [promise-method](https://github.com/wbinnssmith/promise-method) - Standalone `bluebird.method`. Turn a synchronously-returning method into a promise-returning one.
 * [promise-props](https://github.com/exponentjs/promise-props) - Standalone implementation of bluebird's `bluebird.props` or rsvp's `RSVP.hash`
 * [promise-reduce](https://github.com/yoshuawuyts/promise-reduce) - Standalone `bluebird.reduce`. Reduce an array to a promise.
+* [promise-ring](https://github.com/DavidAnson/promise-ring) - Convenience methods for converting Node.js callbacks into native Promises.
 * [promise-some](https://github.com/yoshuawuyts/promise-some) - Standalone `bluebird.some`. Check if an element passes the predicate, return a promise.
 * [promise-try](https://github.com/wbinnssmith/promise-try) - Standalone `bluebird.try`. Execute a synchronously-returning function and return a promise.
 


### PR DESCRIPTION
Wrote this a few months back when I couldn't find quite what I was looking for. Per the overview:

> promise-ring is small, simple library with no dependencies that eases the use of native JavaScript Promises in projects without a Promise library.

https://github.com/DavidAnson/promise-ring