### PR TITLE
Add `promise-until` link and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Native and strictly spec-compliant promises are awesome for compatibility, futur
 * [delay](https://github.com/sindresorhus/delay) - Delay a promise a specified amount of time.
 * [promise-whilst](https://github.com/sindresorhus/promise-whilst) - Calls a function repeatedly while a condition returns true and then resolves the promise.
 * [loud-rejection](https://github.com/sindresorhus/loud-rejection) - Make unhandled promise rejections fail loudly instead of the default silent fail.
-* [promise-until](https://github.com/busterc/promise-until) - Calls a function repeatedly until a condition returns true and then resolves the promise.
+* [promise-until](https://github.com/busterc/promise-until) - Calls a function repeatedly if a condition returns false and until the condition returns true and then resolves the promise.
 
 ## License
 Licensed under the [Creative Commons CC0 License](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Native and strictly spec-compliant promises are awesome for compatibility, futur
 * [delay](https://github.com/sindresorhus/delay) - Delay a promise a specified amount of time.
 * [promise-whilst](https://github.com/sindresorhus/promise-whilst) - Calls a function repeatedly while a condition returns true and then resolves the promise.
 * [loud-rejection](https://github.com/sindresorhus/loud-rejection) - Make unhandled promise rejections fail loudly instead of the default silent fail.
+* [promise-until](https://github.com/busterc/promise-until) - Calls a function repeatedly until a condition returns true and then resolves the promise.
 
 ## License
 Licensed under the [Creative Commons CC0 License](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
I added the `promise-until` module link and description to the
`Convenience Utilities` section.