### PR TITLE
Add `promise-do-until` link and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Native and strictly spec-compliant promises are awesome for compatibility, futur
 * [promise-whilst](https://github.com/sindresorhus/promise-whilst) - Calls a function repeatedly while a condition returns true and then resolves the promise.
 * [loud-rejection](https://github.com/sindresorhus/loud-rejection) - Make unhandled promise rejections fail loudly instead of the default silent fail.
 * [promise-until](https://github.com/busterc/promise-until) - Calls a function repeatedly if a condition returns false and until the condition returns true and then resolves the promise.
+* [promise-do-until](https://github.com/busterc/promise-do-until) - Calls a function repeatedly until a condition returns true and then resolves the promise.
 
 ## License
 Licensed under the [Creative Commons CC0 License](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
I added the `promise-do-until` module link and description to the
`Convenience Utilities` section.