### PR TITLE
Add `promise-do-whilst` link and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@ Native and strictly spec-compliant promises are awesome for compatibility, futur
 * [lie-fs](https://www.npmjs.com/package/lie-fs) - Promise wrappers for Node's FS API.
 * [immediate-promise](https://github.com/sindresorhus/immediate-promise) - Returns a promise resolved in the next event loop - think `setImmediate()`.
 * [delay](https://github.com/sindresorhus/delay) - Delay a promise a specified amount of time.
-* [promise-whilst](https://github.com/sindresorhus/promise-whilst) - Calls a function repeatedly while a condition returns true and then resolves the promise.
+* [promise-whilst](https://github.com/sindresorhus/promise-whilst) - Calls a function repeatedly if and while a condition returns true and then resolves the promise.
 * [loud-rejection](https://github.com/sindresorhus/loud-rejection) - Make unhandled promise rejections fail loudly instead of the default silent fail.
 * [promise-until](https://github.com/busterc/promise-until) - Calls a function repeatedly if a condition returns false and until the condition returns true and then resolves the promise.
 * [promise-do-until](https://github.com/busterc/promise-do-until) - Calls a function repeatedly until a condition returns true and then resolves the promise.
+* [promise-do-whilst](https://github.com/busterc/promise-do-whilst) - Calls a function repeatedly while a condition returns true and then resolves the promise.
 
 ## License
 Licensed under the [Creative Commons CC0 License](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
- I added the `promise-do-until` module link and description to the
  `Convenience Utilities` section.
- I added clarification to the `promise-whilst` description to help
  discern differences with `promise-do-whilst`.