### PR TITLE
Add promise-nodeify

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Native and strictly spec-compliant promises are awesome for compatibility, futur
 * [promise-do-until](https://github.com/busterc/promise-do-until) - Calls a function repeatedly until a condition returns true and then resolves the promise.
 * [promise-do-whilst](https://github.com/busterc/promise-do-whilst) - Calls a function repeatedly while a condition returns true and then resolves the promise.
 * [promise-semaphore](https://github.com/samccone/promise-semaphore) - Push a set of work to be done in a configurable serial fashion
+* [promise-nodeify](https://github.com/kevinoid/promise-nodeify) - Standalone `nodeify` method which calls a Node-style callback on resolution or rejection.
 
 ## License
 Licensed under the [Creative Commons CC0 License](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This module is a standalone version of the `nodeify` method provided by some promise libraries including bluebird, then/promise, and when.js (which uses the name `bindCallback`) but not provided by many libraries including ES2015 native promises.

It's pretty small, but I've found it to be useful and thought you might as well.
