### PR TITLE
add rubico to other libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Native and strictly spec-compliant promises are awesome for compatibility, futur
 * [promise-do-whilst](https://github.com/busterc/promise-do-whilst) - Calls a function repeatedly while a condition returns true and then resolves the promise.
 * [promise-semaphore](https://github.com/samccone/promise-semaphore) - Push a set of work to be done in a configurable serial fashion
 * [promise-nodeify](https://github.com/kevinoid/promise-nodeify) - Standalone `nodeify` method which calls a Node-style callback on resolution or rejection.
+* [rubico](https://github.com/a-synchronous/rubico) - 🏞 [a]synchronous functional syntax
 
 ## License
 Licensed under the [Creative Commons CC0 License](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
I believe rubico should make this list because rubico simplifies asynchronous programming in a functional way. For example, it would turn this
```javascript
Promise.all(array.map(doSomethingAsync))
```

into this
```javascript
map(doSomethingAsync)(array)
```